### PR TITLE
Switch to using setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,43 @@
+[metadata]
+name = MCWorldLib
+version = 0.2019.12
+author = Rodrigo Silva (MestreLion)
+author_email = minecraft@rodrigosilva.com
+description = Yet another python library to manipulate Minecraft save data
+long_description = file: README.md
+long_description_content_type = 'text/markdown'
+keywords =
+    minecraft
+    save
+    nbt
+    chunk
+    region
+    world
+    library
+url = https://github.com/MestreLion/mcworldlib
+project_urls = 
+    Bug Tracker = https://github.com/MestreLion/mcworldlib/issues
+    Source Code = https://github.com/MestreLion/mcworldlib
+license = GPLv3+
+classifiers = 
+    Development Status :: 1 - Planning
+    Intended Audience :: Developers
+    License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)
+    Natural Language :: English
+    Operating System :: OS Independent
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Topic :: Games/Entertainment
+    Topic :: Software Development :: Libraries :: Python Modules
+packages = find:
+include_package_data = true
+
+[options]
+install_requires =
+    nbtlib
+    tqdm
+    importlib; python_version == ">=3.6"
+
+[options.package_data]
+* = *.md, LICENSE*

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,5 @@
 #!/usr/bin/env python3
 
-from importlib import import_module
-from os import path
-
-from setuptools import setup, find_packages
-#
-#
-# packages = find_packages()
-# projname = packages[0]
-# project = import_module(projname)
-# projdir = path.abspath(path.dirname(__file__))
-#
-# with open(path.join(projdir, 'README.md'), encoding='utf-8') as f:
-#     readme = f.read().strip()
+from setuptools import setup
 
 setup()

--- a/setup.py
+++ b/setup.py
@@ -4,50 +4,14 @@ from importlib import import_module
 from os import path
 
 from setuptools import setup, find_packages
+#
+#
+# packages = find_packages()
+# projname = packages[0]
+# project = import_module(projname)
+# projdir = path.abspath(path.dirname(__file__))
+#
+# with open(path.join(projdir, 'README.md'), encoding='utf-8') as f:
+#     readme = f.read().strip()
 
-
-packages = find_packages()
-projname = packages[0]
-project = import_module(projname)
-projdir = path.abspath(path.dirname(__file__))
-
-with open(path.join(projdir, 'README.md'), encoding='utf-8') as f:
-    readme = f.read().strip()
-
-setup(
-    name             = project.__project__,
-    version          = project.__version__,
-    author           = project.__author__,
-    author_email     = project.__email__,
-    description      = project.__doc__.strip(),
-    long_description = readme,
-    long_description_content_type = 'text/markdown',
-    keywords         = "minecraft save nbt chunk region world library",
-    url              = f"https://github.com/MestreLion/{projname}",
-    project_urls     = {
-        "Bug Tracker": f"https://github.com/MestreLion/{projname}/issues",
-        "Source Code": f"https://github.com/MestreLion/{projname}",
-    },
-    license          = 'GPLv3+',
-    classifiers      = [
-        "Development Status :: 1 - Planning",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
-        "Natural Language :: English",
-        "Operating System :: OS Independent",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Topic :: Games/Entertainment",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-    ],
-    packages         = packages,
-    package_data     = {
-        '': ['*.md', 'LICENSE*'],
-    },
-    python_requires  = '>=3.6',
-    install_requires = [
-        'nbtlib',
-        'tqdm',
-    ],
-)
+setup()


### PR DESCRIPTION
Running `pip install .` or `python -m setup.py install` runs into import errors if the package dependencies are not met. This project lacks a requirements.txt file, and the readme doesn't specify the dependencies either, so it's an extra undocumented step to complete before installing. Ideally, a package should be able to be installed and automatically pull in its dependencies unless the user specifies otherwise.

Because the package `__init__.py` imports all from its submodules, importing the package requires the dependencies to be installed, which causes an `ImportError` when running setup.py, because it imports the package.

Abstracting all of the setuptools options into a setup.cfg file without referencing the package attributes resolves the issue, and allows the package to import all from the submodules and maintain package metadata attributes for referencing via other code.

Additionally, a setup.cfg file is generally easier to maintain than direct `setuptools.setup()` keyword arguments in a python file.