### PR TITLE
Warn for region header mismatches

### DIFF
--- a/mcworldlib/cli.py
+++ b/mcworldlib/cli.py
@@ -17,8 +17,7 @@ __all__ = [
 import argparse
 import logging
 
-
-log = logging.getLogger(__name__)
+from .logger import log
 
 
 def basic_parser(description=None,

--- a/mcworldlib/cli.py
+++ b/mcworldlib/cli.py
@@ -17,7 +17,7 @@ __all__ = [
 import argparse
 import logging
 
-from .logger import log
+log = logging.getLogger(__name__)
 
 
 def basic_parser(description=None,

--- a/mcworldlib/logger.py
+++ b/mcworldlib/logger.py
@@ -1,0 +1,6 @@
+import logging
+
+stdout_handler = logging.StreamHandler()
+stdout_handler.setLevel(logging.WARNING)
+log = logging.getLogger(__name__)
+log.addHandler(stdout_handler)

--- a/mcworldlib/logger.py
+++ b/mcworldlib/logger.py
@@ -1,6 +1,0 @@
-import logging
-
-stdout_handler = logging.StreamHandler()
-stdout_handler.setLevel(logging.WARNING)
-log = logging.getLogger(__name__)
-log.addHandler(stdout_handler)

--- a/mcworldlib/region.py
+++ b/mcworldlib/region.py
@@ -15,6 +15,7 @@ __all__ = ['RegionFile']  # Not worth exporting RegionChunk yet
 import collections.abc
 import gzip
 import io
+import logging
 import os.path
 import re
 import struct
@@ -24,8 +25,6 @@ import numpy
 
 from . import chunk
 from . import util as u
-
-from .logger import log
 
 
 # https://minecraft.gamepedia.com/Region_file_format
@@ -45,6 +44,8 @@ COMPRESSION_TYPES = (
     COMPRESSION_GZIP,
     COMPRESSION_ZLIB,
 )
+
+log = logging.getLogger(__name__)
 
 
 class RegionError(u.MCError): pass

--- a/mcworldlib/region.py
+++ b/mcworldlib/region.py
@@ -145,7 +145,7 @@ class RegionFile(collections.abc.MutableMapping):
             # Warn when sector_count does not match expected as declared in the region header.
             # Sometimes Minecraft saves sector_count + 1 when chunk length
             # (including header) is an exact multiple of SECTOR_BYTES
-            if chunk.sector_count > sector_count > chunk.sector_count + 1:
+            if (chunk.sector_count != sector_count) and (chunk.sector_count + 1 != sector_count):
                 log.warning(
                     f'Length mismatch for region {self.pos} in chunk {pos}:'
                     f' region header declares {sector_count} {SECTOR_BYTES}-byte sectors,'

--- a/mcworldlib/region.py
+++ b/mcworldlib/region.py
@@ -145,12 +145,13 @@ class RegionFile(collections.abc.MutableMapping):
             # Warn when sector_count does not match expected as declared in the region header.
             # Sometimes Minecraft saves sector_count + 1 when chunk length
             # (including header) is an exact multiple of SECTOR_BYTES
-            if (chunk.sector_count != sector_count) and (chunk.sector_count + 1 != sector_count):
-                log.warning(
-                    f'Length mismatch for region {self.pos} in chunk {pos}:'
-                    f' region header declares {sector_count} {SECTOR_BYTES}-byte sectors,'
-                    f' but chunk data required {chunk.sector_count}.'
-                )
+            if chunk.sector_count != sector_count:
+                if chunk.sector_count + 1 != sector_count:
+                    log.warning(
+                        f'Length mismatch for region {self.pos} in chunk {pos}:'
+                        f' region header declares {sector_count} {SECTOR_BYTES}-byte sectors,'
+                        f' but chunk data required {chunk.sector_count}.'
+                    )
 
             chunk.region = self
             chunk.pos = pos

--- a/mcworldlib/region.py
+++ b/mcworldlib/region.py
@@ -146,13 +146,12 @@ class RegionFile(collections.abc.MutableMapping):
             # Warn when sector_count does not match expected as declared in the region header.
             # Sometimes Minecraft saves sector_count + 1 when chunk length
             # (including header) is an exact multiple of SECTOR_BYTES
-            if chunk.sector_count != sector_count:
-                if chunk.sector_count + 1 != sector_count:
-                    log.warning(
-                        f'Length mismatch for region {self.pos} in chunk {pos}:'
-                        f' region header declares {sector_count} {SECTOR_BYTES}-byte sectors,'
-                        f' but chunk data required {chunk.sector_count}.'
-                    )
+            if sector_count not in {chunk.sector_count, chunk.sector_count + 1}:
+                log.warning(
+                    f'Length mismatch for region {self.pos} in chunk {pos}:'
+                    f' region header declares {sector_count} {SECTOR_BYTES}-byte sectors,'
+                    f' but chunk data required {chunk.sector_count}.'
+                )
 
             chunk.region = self
             chunk.pos = pos

--- a/mcworldlib/world.py
+++ b/mcworldlib/world.py
@@ -12,6 +12,7 @@ Exported items:
 __all__ = ['load', 'World']
 
 
+import logging
 import os.path
 
 import tqdm
@@ -21,7 +22,7 @@ from . import nbt
 from . import region
 from . import util as u
 
-from .logger import log
+log = logging.getLogger(__name__)
 
 
 class WorldNotFoundError(u.MCError, IOError): pass

--- a/mcworldlib/world.py
+++ b/mcworldlib/world.py
@@ -13,7 +13,6 @@ __all__ = ['load', 'World']
 
 
 import os.path
-import logging
 
 import tqdm
 
@@ -22,8 +21,7 @@ from . import nbt
 from . import region
 from . import util as u
 
-
-log = logging.getLogger(__name__)
+from .logger import log
 
 
 class WorldNotFoundError(u.MCError, IOError): pass


### PR DESCRIPTION
This PR addresses #7 and replaces `assert` statements with logging at the warning level.

Additionally, it adds a `logger` module which supplies `log` with a stdout stream handler attached set to the warning level.

I noticed that some logging verbosity arguments are in `cli.py` but the stuff in `cli.py` doesn't appear to be actively used yet. I have a [gist](https://gist.github.com/ievans3024/4bbc63643ac197135a308c36220f9928) that demonstrates using `--verbose/-v` as a counter to determine log level, that could be useful, but is outside the scope of this PR.