### PR TITLE
Update Minecraft Wiki links to new domain after fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ on top of it and add more _semantics_ to that data.
 ---
 Features
 --------
-- Read and write `.dat` [NBT](https://minecraft.fandom.com/wiki/NBT_format)
+- Read and write `.dat` [NBT](https://minecraft.wiki/w/NBT_format)
   files, both uncompressed and gzip-compressed.
-- Read and write `.mca`/`.mcr` [Anvil](https://minecraft.fandom.com/wiki/Anvil_file_format)
+- Read and write `.mca`/`.mcr` [Anvil](https://minecraft.wiki/w/Anvil_file_format)
   region files, lazily loading their contents only when the data is actually
   requested, also monitoring content changes to efficiently save back to disk
   only the needed files.

--- a/mcworldlib/anvil.py
+++ b/mcworldlib/anvil.py
@@ -420,7 +420,7 @@ class RegionChunk(c.Chunk):
               region: AnvilFile = None, pos=None, timestamp=None,
               *args, **kwargs) -> T:
         """
-        https://minecraft.fandom.com/wiki/Region_file_format#Chunk_data
+        https://minecraft.wiki/w/Region_file_format#Chunk_data
         https://www.reddit.com/r/technicalminecraft/comments/e4wxb6/
         """
         if not hasattr(buff, 'read'):  # assume bytes data

--- a/mcworldlib/anvil.py
+++ b/mcworldlib/anvil.py
@@ -36,7 +36,7 @@ from . import util as u
 
 
 # Constants
-# https://minecraft.gamepedia.com/Region_file_format
+# https://minecraft.wiki/w/Region_file_format
 CHUNK_LOCATION_BYTES = 4  # Chunk offset and sector count. Must be power of 2
 CHUNK_TIMESTAMP_BYTES = 4  # Unix timestamp, seconds after epoch.
 CHUNK_SECTOR_COUNT_BYTES = 1  # Assumed to be the least significant from CHUNK_LOCATION_BYTES
@@ -105,7 +105,7 @@ class AnvilFile(collections.abc.MutableMapping):
     def parse(cls: t.Type[RT], buff: t.BinaryIO, **initkw) -> RT:
         """Parse region from file-like object, build an instance and return it
 
-        https://minecraft.gamepedia.com/Region_file_format
+        https://minecraft.wiki/w/Region_file_format
         """
         self: RT = cls(**initkw)
         if not self.filename:

--- a/mcworldlib/nbt.py
+++ b/mcworldlib/nbt.py
@@ -229,7 +229,7 @@ def deep_walk(
         parent[key] == tag
 
     Path is the parent tag location in the root tag, compatible with the format
-    described at https://minecraft.fandom.com/wiki/NBT_path_format. That holds
+    described at https://minecraft.wiki/w/NBT_path_format. That holds
     true even when path is empty, i.e., when the parent tag is root. So:
         root[path][name] == root[path[name]] == tag
 


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all the URLs to the new domain: minecraft.wiki