### PR TITLE
Support parsing block_states with version greater than 1.18

### DIFF
--- a/mcworldlib/chunk.py
+++ b/mcworldlib/chunk.py
@@ -167,7 +167,7 @@ class Chunk(nbt.Root):
             if not palette:
                 # Infer from data length (not the way described by Wiki!)
                 return bits_from_data()
-            bit_length = max(self.BS_MIN_BITS, (len(palette)).bit_length())
+            bit_length = max(self.BS_MIN_BITS, (len(palette) - 1).bit_length())
             assert bit_length == bits_from_data(), \
                 f"BlockState bits mismatch: {bit_length} != {bits_from_data()}"
             return bit_length

--- a/mcworldlib/chunk.py
+++ b/mcworldlib/chunk.py
@@ -90,11 +90,11 @@ class Chunk(nbt.Root):
             yield (Y, *blocks[Y])
 
     
-    def get_blocks(self, Y: int, _section=None):
+    def get_blocks(self):
         if self.is_version_1_21():
-            return self.get_blocks_1_21(Y, _section)
+            yield self.get_blocks_1_21()
         else:
-            return self.get_blocks_old(Y, _section)
+            yield self.get_blocks_old()
 
 
     def get_section_blocks(self, Y: int, _section=None):

--- a/mcworldlib/chunk.py
+++ b/mcworldlib/chunk.py
@@ -51,7 +51,7 @@ class Chunk(nbt.Root):
         Palette, Indexes: See get_section_blocks()
         """
         blocks = {}
-        for section in self.data_root['Sections']:
+        for section in self.data_root['sections']:
             # noinspection PyPep8Naming
             Y = int(section['Y'])
             palette, indexes = self.get_section_blocks(Y, _section=section)
@@ -70,17 +70,23 @@ class Chunk(nbt.Root):
         """
         section = _section
         if not section:
-            for section in self.data_root.get('Sections', []):
+            for section in self.data_root.get('sections', []):
                 if section.get('Y') == Y:
                     break
             else:
                 return None, None
 
-        if 'Palette' not in section or 'BlockStates' not in section:
+        if 'block_states' not in section:
             return None, None
 
-        palette = section['Palette']
-        indexes = self._decode_blockstates(section['BlockStates'], palette)
+        states = section['block_states']
+
+        palette = states['palette']
+
+        if 'data' not in states:
+            return palette, numpy.zeros((u.SECTION_HEIGHT, *reversed(u.CHUNK_SIZE)))
+
+        indexes = self._decode_blockstates(states['data'], palette)
         return palette, indexes.reshape((u.SECTION_HEIGHT, *reversed(u.CHUNK_SIZE)))
 
     def _decode_blockstates(self, data, palette=None):

--- a/mcworldlib/chunk.py
+++ b/mcworldlib/chunk.py
@@ -92,9 +92,9 @@ class Chunk(nbt.Root):
     
     def get_blocks(self):
         if self.is_version_1_21():
-            yield self.get_blocks_1_21()
+            return self.get_blocks_1_21()
         else:
-            yield self.get_blocks_old()
+            return self.get_blocks_old()
 
 
     def get_section_blocks(self, Y: int, _section=None):

--- a/mcworldlib/tree.py
+++ b/mcworldlib/tree.py
@@ -209,9 +209,9 @@ def is_nbt_container(tag: 'nbt.AnyTag') -> bool:
 def tests():
     import json
     for data in (
-        json.load(open("../data/New World/advancements/"
+        json.load(open("data/New World/advancements/"
                        "8b4accb8-d952-4050-97f2-e00c4423ba92.json")),
-        nbt.load_dat("../data/New World/level.dat"),
+        nbt.load_dat("data/New World/level.dat"),
         [{"x": 1, "y": 2}, "a", ((4, {"z": 5}, "b"), 6, "c")],
         {"name": ["Rodrigo", ("E", "S"), "Silva"], "alias": "MestreLion"}
     ):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python3
+"""
+Run tests by `python tests/tests.py`
+"""
 
 import io
 import logging
 import os.path
 import sys
 
+sys.path.append(os.path.abspath("."))
 import mcworldlib as mc
-
 
 logging.basicConfig(level=logging.DEBUG, format='%(levelname)-6s: %(message)s')
 
@@ -80,7 +83,7 @@ def diamonds():
 
 
 def new_diamonds():
-    world = mc.load('New World')
+    world = mc.load('data/New World')
 
     for item in world.level['Data']['Player']['Inventory']:
         item['id'] = mc.String('minecraft:diamond_block')
@@ -128,7 +131,7 @@ def player_pos():
 
 def blocks(w=None):
     if w is None:
-        w = mc.load('New World')
+        w = mc.load('data/New World')
 
     for chunk in [w.player.get_chunk()]:  # w.get_chunks(False):
         print(chunk)


### PR DESCRIPTION
Fix relate issue: #10, cite: https://minecraft.wiki/w/Chunk_format

But in contrast, this pr will cause that deprecating the support for old versions. So maybe creating a new branch is a better idea?

![image](https://github.com/MestreLion/mcworldlib/assets/73207484/98872c28-ad00-4231-823b-d08e5b2515b5)
