### PR TITLE
feat: Support READ external MCC data file

### DIFF
--- a/mcworldlib/anvil.py
+++ b/mcworldlib/anvil.py
@@ -443,9 +443,14 @@ class RegionChunk(c.Chunk):
             )
 
         if external:
-            raise ChunkError('External MCC data file is not yet supported')
+            fixedPos = region.pos.to_chunk(pos)
+            mcc_filename = region.filename.parent / f"c.{fixedPos[0]}.{fixedPos[1]}.mcc"
+            with open(mcc_filename, mode='rb') as f:
+                compressed_data = f.read()
+        else:
+            compressed_data = buff.read(length)
 
-        data = cls.decompress[compression](buff.read(length))
+        data = cls.decompress[compression](compressed_data)
         self: T = super().parse(io.BytesIO(data), *args, **kwargs)
 
         self.region = region


### PR DESCRIPTION
READ external MCC data file was not supported. There used to be code https://github.com/MestreLion/mcworldlib/blob/3dc4477eb4f6ee2133042bf829c12a04baba7b35/mcworldlib/anvil.py#L445-L446

This PR implements support for reading external MCC data file

Tested with MC 1.19.2